### PR TITLE
Major changes to observation, action selection, reward calculation and randomization behavior

### DIFF
--- a/main.py
+++ b/main.py
@@ -180,7 +180,7 @@ if __name__ == "__main__":
             )
             # Convert the observation to a tensor
             reward = torch.tensor([reward], device=device)
-            if reward > 0:
+            if reward > 0 or i_episode % 1000 == 0:
                 logger.debug(f"Reward: {reward.item()}")
                 logger.debug(f"Cauldron: {info['current_cauldron'].name}")
                 logger.debug(f"Recipe Name: {info['current_recipe'].name}")

--- a/potionomics_env/main.py
+++ b/potionomics_env/main.py
@@ -73,10 +73,12 @@ class PotionomicsEnvironment(gym.Env):
         # self.recipe: PotionomicsPotionRecipe = self.all_recipes[
         #     np.random.choice(len(self.all_recipes), 1)[0]
         # ]
-        self.recipe: PotionomicsPotionRecipe = self.all_recipes[4]
+        self.recipe: PotionomicsPotionRecipe = self.all_recipes[
+            np.random.choice(len(self.all_recipes), 1)[0]
+        ]
         self.num_ingredients: np.ndarray = np.ascontiguousarray(
             np.random.randint(
-                low=1,
+                low=0,
                 high=self.cauldron.max_num_items_allowed + 1,
                 size=len(self.all_ingredients) + 1,
             )
@@ -87,7 +89,7 @@ class PotionomicsEnvironment(gym.Env):
             np.zeros(shape=(len(self.all_ingredients) + 1,), dtype=np.int_)
         )
         self.current_stability = PotionomicsPotionStability.CANNOTMAKE
-        self.stability_rewards:List[float] = [0.0, 0.05, 0.5, 0.75, 1.0]
+        self.stability_rewards: List[float] = [0.0, 0.25, 0.5, 0.75, 1.0]
         self.potion_tier: PotionomicsPotionTier = None
         self.potion_traits: np.ndarray = np.zeros((5,))
         self.potion_magimin_thresholds_array = np.array(
@@ -582,7 +584,7 @@ class PotionomicsEnvironment(gym.Env):
 
     def calculate_stability_bonus(self) -> float:
         """Calculate the stability bonus reward.
-        
+
         :return: A floating-point value that represents the bonus reward for
         creating high-stability potions.
         :rtype: float
@@ -682,7 +684,7 @@ class PotionomicsEnvironment(gym.Env):
         :type options: Dict[str, Any], optional
         """
 
-        super().reset(seed=seed)
+        super().reset()
         self.current_ingredients: np.ndarray = np.ascontiguousarray(
             np.zeros(len(self.all_ingredients) + 1, dtype=np.int_)
         )
@@ -693,7 +695,7 @@ class PotionomicsEnvironment(gym.Env):
         self.potion_traits: np.ndarray = np.zeros((5,))
         self.num_ingredients: np.ndarray = np.ascontiguousarray(
             np.random.randint(
-                low=1,
+                low=0,
                 high=self.cauldron.max_num_items_allowed + 1,
                 size=len(self.all_ingredients) + 1,
             )
@@ -705,7 +707,9 @@ class PotionomicsEnvironment(gym.Env):
         # ].model_copy(deep=True)
         self.cauldron: PotionomicsCauldron = self.all_cauldrons[-1]
         self.cauldron.setup()
-        # self.recipe = self.all_recipes[np.random.choice(len(self.all_recipes), 1)[0]]
+        self.recipe = self.all_recipes[
+            np.random.choice(len(self.all_recipes), 1)[0]
+        ]
         observation = self._get_obs()
         info = self._get_info()
         return observation, info


### PR DESCRIPTION
# Changes

## Observation Changes

This PR refactors how the observation is constructed. Instead of a sequence of ingredients, it is instead a count-based vector. This effectively shrinks the state space by correctly mimicking the in-game behavior wherein the sequence of ingredients was irrelevant, instead focusing on the resulting set of ingredients.

## Action Masking

This PR adds in action masking to replace the use of negative rewards and action verification (i.e., `legal_move`). Masking out actions that are not valid both increases the stability of the training loop and simplifies the logic within the environment. There are still some logging statements for sanity checking that the agent is not somehow selecting "illegal moves", but these will be removed shortly.

## Reward Changes

The `calculate_stability_bonus` was not well-designed, as the large negative penalty required the rewards to be clipped to the [-1,1] range, and the use of a logarithm was likely not worthwhile.

Additionally, `calculate_stability_bonus` did not align with the game's mechanics, as `CANNOTMAKE` was considered an invalid potion state, meaning there was no point to assigning negative rewards specifically for this tier. Similarly, having less than 2 items in the cauldron was also an invalid state, so both of these were assigned a zero reward output instead.

Having done this, the reward calculation can be redone to forego clipping and re-balanced the stability bonus.

## Randomization Changes

In light of the aforementioned changes, I've re-enabled random potion recipe selection to try and create a robust environment for the agent to train in. I've also set the minimum amount present for any given ingredient to be 0.