### PR TITLE
Updating the Hydra configuration to make it easier to create test cases

### DIFF
--- a/potionomics_env/config/config.yaml
+++ b/potionomics_env/config/config.yaml
@@ -1,5 +1,6 @@
 defaults:
   - _self_
+  - task: default
   - reward: default
 
 

--- a/potionomics_env/config/config.yaml
+++ b/potionomics_env/config/config.yaml
@@ -1,26 +1,24 @@
+defaults:
+  - _self_
+  - reward: default
+
+
 data:
   potionomics_cauldrons: data/potionomics_cauldrons.csv
   potionomics_ingredients: data/potionomics_ingredients.csv
   potionomics_recipes: data/potionomics_recipes.csv
 
 # Configurations of the environment that may change per episode
-episode_cfg:
-  randomize_cauldron: true
-  randomize_recipe: true
-  randomize_ingredient_amount: true
-  # Index of the cauldron to use by default if randomize_cauldron is false
-  default_cauldron_index: 0
-  # Index of the recipe to use by default if randomize_recipe is false
-  default_recipe_index: 0
-  # The default amount of each ingredient available by default if randomize_ingredient_amount is false
-  default_ingredient_amount: 10  
+cauldron:
+  randomize: true
+  cauldron_index: 0
 
+recipe:
+  randomize: true
+  recipe_index: 0
 
-reward_cfg:
-  cannot_make_potion_reward: 0.0 # This covers potion stability being too low and insufficient items in cauldron.
-  stability_reward:
-    - 0.0 # This index is not expected to be used, it is just to keep in-line with the Enum
-    - 0.25
-    - 0.5
-    - 0.75
-    - 1.0
+ingredients:
+  randomize: true
+  minimum_amount: 0
+  maximum_amount: 10
+  allowed_ingredients: null

--- a/potionomics_env/config/reward/default.yaml
+++ b/potionomics_env/config/reward/default.yaml
@@ -1,0 +1,7 @@
+cannot_make_potion_reward: 0.0 # This covers potion stability being too low and insufficient items in cauldron.
+stability_reward:
+  - 0.0 # This index is not expected to be used, it is just to keep in-line with the Enum
+  - 0.25
+  - 0.5
+  - 0.75
+  - 1.0

--- a/potionomics_env/config/task/anuberia_contest.yaml
+++ b/potionomics_env/config/task/anuberia_contest.yaml
@@ -7,4 +7,5 @@ cauldron:
 recipe:
   randomize: false
 ingredients:
+  randomize: false
   allowed_ingredients: null

--- a/potionomics_env/config/task/anuberia_contest.yaml
+++ b/potionomics_env/config/task/anuberia_contest.yaml
@@ -1,0 +1,10 @@
+# @package _global_
+
+### Environment Configuration ###
+cauldron:
+  randomize: false
+  cauldron_index: 37 # Magical_Wasteland_Cauldron_2
+recipe:
+  randomize: false
+ingredients:
+  allowed_ingredients: null

--- a/potionomics_env/config/task/corsac_contest.yaml
+++ b/potionomics_env/config/task/corsac_contest.yaml
@@ -1,0 +1,10 @@
+# @package _global_
+
+### Environment Configuration ###
+cauldron:
+  randomize: false
+  cauldron_index: 10 # Storm_Cauldron_2
+recipe:
+  randomize: false
+ingredients:
+  allowed_ingredients: null

--- a/potionomics_env/config/task/corsac_contest.yaml
+++ b/potionomics_env/config/task/corsac_contest.yaml
@@ -7,4 +7,5 @@ cauldron:
 recipe:
   randomize: false
 ingredients:
+  randomize: false
   allowed_ingredients: null

--- a/potionomics_env/config/task/default.yaml
+++ b/potionomics_env/config/task/default.yaml
@@ -1,0 +1,1 @@
+# @package _global_

--- a/potionomics_env/config/task/finn_contest.yaml
+++ b/potionomics_env/config/task/finn_contest.yaml
@@ -7,5 +7,6 @@ cauldron:
 recipe:
   randomize: false
 ingredients:
+  randomize: false
   allowed_ingredients: null
 

--- a/potionomics_env/config/task/finn_contest.yaml
+++ b/potionomics_env/config/task/finn_contest.yaml
@@ -1,0 +1,11 @@
+# @package _global_
+
+### Environment Configuration ###
+cauldron:
+  randomize: false
+  cauldron_index: 19 # Crystal_Cauldron_2
+recipe:
+  randomize: false
+ingredients:
+  allowed_ingredients: null
+

--- a/potionomics_env/config/task/robin_contest.yaml
+++ b/potionomics_env/config/task/robin_contest.yaml
@@ -7,4 +7,5 @@ cauldron:
 recipe:
   randomize: false
 ingredients:
+  randomize: false
   allowed_ingredients: null

--- a/potionomics_env/config/task/robin_contest.yaml
+++ b/potionomics_env/config/task/robin_contest.yaml
@@ -1,0 +1,10 @@
+# @package _global_
+
+### Environment Configuration ###
+cauldron:
+  randomize: false
+  cauldron_index: 37 # Magical_Wasteland_Cauldron_2
+recipe:
+  randomize: false
+ingredients:
+  allowed_ingredients: null

--- a/potionomics_env/config/task/roxanne_contest.yaml
+++ b/potionomics_env/config/task/roxanne_contest.yaml
@@ -1,0 +1,10 @@
+# @package _global_
+
+### Environment Configuration ###
+cauldron:
+  randomize: false
+  cauldron_index: 2 # Mudpack_Cauldron_0
+recipe:
+  randomize: false
+ingredients:
+  allowed_ingredients: null

--- a/potionomics_env/config/task/roxanne_contest.yaml
+++ b/potionomics_env/config/task/roxanne_contest.yaml
@@ -7,4 +7,5 @@ cauldron:
 recipe:
   randomize: false
 ingredients:
+  randomize: false
   allowed_ingredients: null

--- a/potionomics_env/main.py
+++ b/potionomics_env/main.py
@@ -316,43 +316,40 @@ class PotionomicsEnvironment(gym.Env):
         Both environment initialization and reset call this function.
         """
 
-        # BUG: Random cauldrons will break models that don't have a way to
-        # handle dynamic observation sizes
-        # (if you include them in the observation)
-        if self.env_cfg.episode_cfg.randomize_cauldron:
+        if self.env_cfg.cauldron.randomize:
             self.cauldron: PotionomicsCauldron = self.all_cauldrons[
                 np.random.choice(len(self.all_cauldrons), 1)[0]
             ].model_copy(deep=True)
         else:
             self.cauldron: PotionomicsCauldron = self.all_cauldrons[
-                self.env_cfg.episode_cfg.default_cauldron_index
+                self.env_cfg.cauldron.cauldron_index
             ]
         self.cauldron.setup()
-        if self.env_cfg.episode_cfg.randomize_recipe:
+        if self.env_cfg.recipe.randomize:
             self.recipe: PotionomicsPotionRecipe = self.all_recipes[
                 np.random.choice(len(self.all_recipes), 1)[0]
             ]
         else:
             self.recipe: PotionomicsPotionRecipe = self.all_recipes[
-                self.env_cfg.episode_cfg.default_recipe_index
+                self.env_cfg.recipe.recipe_index
             ]
-        if self.env_cfg.episode_cfg.randomize_ingredient_amount:
+        if self.env_cfg.ingredients.randomize:
             self.num_ingredients: np.ndarray = np.ascontiguousarray(
                 np.random.randint(
-                    low=0,
-                    high=self.cauldron.max_num_items_allowed + 1,
+                    low=self.env_cfg.ingredients.minimum_amount,
+                    high=self.env_cfg.ingredients.maximum_amount + 1,
                     size=len(self.all_ingredients) + 1,
                 )
             )
         else:
             self.num_ingredients = np.ascontiguousarray(
-                [self.env_cfg.episode_cfg.default_ingredient_amount]
+                [self.env_cfg.ingredients.maximum_amount]
                 * (len(self.all_ingredients) + 1)
             )
         self.num_ingredients[0] = 0  # Set the None action to have 0
-        self.stability_reward = self.env_cfg.reward_cfg.stability_reward
+        self.stability_reward = self.env_cfg.reward.stability_reward
         self.cannot_make_potion_reward = (
-            self.env_cfg.reward_cfg.cannot_make_potion_reward
+            self.env_cfg.reward.cannot_make_potion_reward
         )
 
     def insert_item(self, index_of_item_to_insert: int) -> None:


### PR DESCRIPTION
# Changelog

## Splitting up Hydra configuration into multiple files

The main purpose of this PR is to split up the current configuration into separate files to make it easier to test out different setups (e.g., different reward structures).

## Adding tests for RL agent via Hydra configuration

Another addition in this PR is creating test cases that replicate the contest mechanic in the game. However, to avoid having to deal with the "haggling" aspect of the contests, the values proposed in this [Steam Guide](https://steamcommunity.com/sharedfiles/filedetails/?id=2912297813) for the 'No Contest' achievement, wherein the player outright wins the contest due to having strictly better potions, is used.